### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -9,6 +9,7 @@ package log
 import (
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"sync"
@@ -88,6 +89,8 @@ func init() {
 	if v := os.Getenv("DD_LOGGING_RATE"); v != "" {
 		if sec, err := strconv.ParseUint(v, 10, 64); err != nil {
 			Warn("Invalid value for DD_LOGGING_RATE: %v", err)
+		} else if sec > uint64(math.MaxInt64) {
+			Warn("Value for DD_LOGGING_RATE too large: %v (max: %v)", sec, math.MaxInt64)
 		} else {
 			errrate = time.Duration(sec) * time.Second
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/KoddiDev/dd-trace-go/security/code-scanning/2](https://github.com/KoddiDev/dd-trace-go/security/code-scanning/2)

To fix the problem, we need to ensure that the value parsed from the environment variable is within the valid range for `time.Duration` (i.e., it must not exceed `math.MaxInt64`). The best way is to check that `sec` is less than or equal to `math.MaxInt64` before converting it to `time.Duration`. If the value is out of bounds, we should log a warning and leave `errrate` unchanged (or set it to a safe default). This change should be made in the `init()` function in `internal/log/log.go`, specifically around lines 88–93. We will need to import the `math` package to access `math.MaxInt64`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
